### PR TITLE
Better exception handling

### DIFF
--- a/lib/heroku/nav.rb
+++ b/lib/heroku/nav.rb
@@ -38,7 +38,7 @@ module Heroku
             raw = RestClient.get(resource_url, :accept => :json).to_s
             return JSON.parse(raw)
           end
-        rescue Exception => e
+        rescue Timeout::Error, StandardError => e
           STDERR.puts "Failed to fetch the Heroku #{resource}: #{e.class.name} - #{e.message}"
           {}
         end
@@ -103,7 +103,7 @@ module Heroku
           Timeout.timeout(4) do
             RestClient.get(resource_url).to_s
           end
-        rescue => e
+        rescue Timeout::Error, StandardError => e
           STDERR.puts "Failed to fetch the Heroku #{resource}: #{e.class.name} - #{e.message}"
           {}
         end

--- a/spec/api_spec.rb
+++ b/spec/api_spec.rb
@@ -15,7 +15,7 @@ describe "Api" do
   end
 
   it "doesn't raise" do
-    RestClient.stubs(:get).raises("error")
+    RestClient.stubs(:get).raises(Timeout::Error)
     lambda { Heroku::Nav::Header.fetch }.should.not.raise
   end
 

--- a/spec/nav_spec.rb
+++ b/spec/nav_spec.rb
@@ -120,11 +120,11 @@ describe Heroku::Nav::Internal do
 end
 
 describe Heroku::Nav::Provider do
-  before do
-    Heroku::Nav::Provider.stubs(:fetch).returns('<!-- heroku header -->')
-  end
-
   describe "when there's no heroku-nav-data cookie" do
+    before do
+      Heroku::Nav::Provider.stubs(:fetch).returns('<!-- heroku header -->')
+    end
+
     def app
       make_app { use Heroku::Nav::Provider }
     end
@@ -137,6 +137,7 @@ describe Heroku::Nav::Provider do
 
   describe "when there's a heroku-nav-data cookie" do
     before do
+      Heroku::Nav::Provider.stubs(:fetch).returns('<!-- heroku header -->')
       set_cookie("heroku-nav-data=data")
     end
 
@@ -170,6 +171,16 @@ describe Heroku::Nav::Provider do
         get '/', :body => '<html><body>hi</body>'
         last_response.body.should.equal '<html><body><!-- \+ nav -->hi</body>'
       end
+    end
+  end
+
+  describe "when there's an error fetching nav" do
+    before do
+      RestClient.stubs(:get).raises(Timeout::Error)
+    end
+
+    it "should not raise" do
+      lambda { Heroku::Nav::Provider.fetch }.should.not.raise
     end
   end
 end


### PR DESCRIPTION
Changed in two places:
1. Was rescuing Exception in Heroku::Nav::Header, but I made it more specific by rescuing Timeout::Error and StandardError. This will allow it to correctly handle other exceptions like interrupts.
2. Was rescuing StandardError in Heroku::Nav::Provider, which was not catching Timeout::Error. Made the same change here. This will allow it to allow it to gracefully handle timeout exceptions.

Thanks!
--Brandon
